### PR TITLE
[Feature] adjust damage check logic to allow hammer to break

### DIFF
--- a/common/src/main/java/pro/mikey/justhammers/HammerItem.java
+++ b/common/src/main/java/pro/mikey/justhammers/HammerItem.java
@@ -103,9 +103,20 @@ public class HammerItem extends PickaxeItem {
         return baseModified + ((int) (tier.durability() * 2.5F) + (200 * level)) * level;
     }
 
+    private boolean isHammerBroken(ItemStack itemStack) {
+        return isHammerBroken(itemStack, 0);
+    }
+
+    private boolean isHammerBroken(ItemStack itemStack, int offset) {
+        var isBreakable = SimpleJsonConfig.INSTANCE.breakableHammer.get().getAsBoolean();
+        var durabilityOffset = isBreakable ? 0 : -1;
+        var maxDamage = itemStack.getMaxDamage() + durabilityOffset;
+        return itemStack.getDamageValue() + offset >= maxDamage;
+    }
+
     @Override
     public float getDestroySpeed(ItemStack itemStack, BlockState blockState) {
-        if (itemStack.getMaxDamage() - itemStack.getDamageValue() <= 1) {
+        if (isHammerBroken(itemStack)) {
             return -1f;
         }
 
@@ -156,7 +167,7 @@ public class HammerItem extends PickaxeItem {
             }
 
             // Prevent the hammer from breaking if the damage is too high
-            if (!player.isCreative() && (hammerStack.getDamageValue() + (damage + 1)) >= hammerStack.getMaxDamage() - 1) {
+            if (!player.isCreative() && isHammerBroken(hammerStack, damage + 1)) {
                 break;
             }
 

--- a/common/src/main/java/pro/mikey/justhammers/config/SimpleJsonConfig.java
+++ b/common/src/main/java/pro/mikey/justhammers/config/SimpleJsonConfig.java
@@ -46,6 +46,12 @@ public enum SimpleJsonConfig {
             "The percentage of durability restored per repair item for netherite hammers"
     );
 
+    public final CommentedEntry breakableHammer = create(
+            "breakableHammer",
+            new JsonPrimitive(true),
+            "Set to true to allow hammers to break at 0 durability"
+    );
+
     private JsonObject config;
 
     public void load() {


### PR DESCRIPTION
I added a config option, `breakableHammer,` which allows the hammer to break when it reaches zero durability; if not enabled, it will keep the current behavior.